### PR TITLE
Highlight :foo? and 10_000 correctly

### DIFF
--- a/RBS.sublime-syntax
+++ b/RBS.sublime-syntax
@@ -18,14 +18,14 @@ variables:
 
   interface: '_[A-Z]{{word}}*'
   any_character: '(?=\S)'
-  integer: '(?:\b\d+\b)|(?:[+-]?\d+\b)'
+  integer: '(?:\b\d(?:\d|_(?!_))*\b)|(?:[+-]?\d(?:\d|_(?!_))*\b)'
   sq_string: '''[^'']*'''
   dq_string: '"(?:[^"]|\\")*"'
   at_ident: '@{{ident}}'
   at2_ident: '@@{{ident}}'
   gident: '\${{ident}}'
   symbol_oprs: '\||&|/|%|~|`|\^|===|==|=~|!=|!~|!|<=>|<=|<<|<|>=|>>|>|-@|-|\+@|\+|\*\*|\*|\[\]=|\[\]'
-  symbol: ':(?:{{ident}}\b|{{sq_string}}|{{dq_string}}|{{at_ident}}\b|{{at2_ident}}\b|{{gident}}\b|{{symbol_oprs}})'
+  symbol: ':(?:{{ident}}(?:[?!]|\b)|{{sq_string}}|{{dq_string}}|{{at_ident}}\b|{{at2_ident}}\b|{{gident}}\b|{{symbol_oprs}})'
   method_name: '(?:\b{{ident}}[?!]?)|{{symbol_oprs}}'
   attribute: '{{ident}}'
 


### PR DESCRIPTION
Currently, `:foo?` highlights as an optional `:foo`, not the symbol `:foo?`. Additionally, `10_000` breaks and only highlights `000`.